### PR TITLE
avoid including <stdatomic.h> in public headers to be C++ compatible

### DIFF
--- a/include/groufix/core/renderer.h
+++ b/include/groufix/core/renderer.h
@@ -352,9 +352,9 @@ typedef struct GFXRenderable
 	GFXTechnique* technique;
 	GFXPrimitive* primitive;
 
-	atomic_bool lock;
-	uintptr_t   pipeline;
-	uintmax_t   gen;
+	_Atomic bool  lock;
+	uintptr_t     pipeline;
+	uintmax_t     gen;
 
 } GFXRenderable;
 
@@ -367,7 +367,7 @@ typedef struct GFXComputable
 	// All read-only.
 	GFXTechnique* technique;
 
-	atomic_uintptr_t pipeline;
+	_Atomic uintptr_t pipeline;
 
 } GFXComputable;
 

--- a/include/groufix/def.h
+++ b/include/groufix/def.h
@@ -19,8 +19,6 @@
 	#error "Host platform does not support atomics."
 #endif
 
-#include <stdatomic.h>
-
 
 /**
  * Identification of the host platform.

--- a/src/groufix/core.h
+++ b/src/groufix/core.h
@@ -22,6 +22,8 @@
 #define GLFW_INCLUDE_NONE
 #include "GLFW/glfw3.h"
 
+#include <stdatomic.h>
+
 
 // Least Vulkan version that must be supported.
 #define _GFX_VK_API_VERSION VK_MAKE_API_VERSION(0,1,1,0)


### PR DESCRIPTION
C++ is annoying: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=60932.

But now it's at least possible to use groufix from C++.