### PR TITLE
Fix an operator precedence error

### DIFF
--- a/src/groufix/core/backing.c
+++ b/src/groufix/core/backing.c
@@ -141,7 +141,8 @@ static bool _gfx_alloc_backing(GFXRenderer* renderer, _GFXAttach* attach)
 	VkMemoryPropertyFlags optimal =
 		VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
 		((usage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) ?
-			VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT : 0);
+			VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT :
+			(VkMemoryPropertyFlags)0);
 
 	if (!_gfx_allocd(&renderer->allocator, &backing->alloc,
 		VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, optimal,

--- a/src/groufix/core/backing.c
+++ b/src/groufix/core/backing.c
@@ -140,8 +140,8 @@ static bool _gfx_alloc_backing(GFXRenderer* renderer, _GFXAttach* attach)
 	// Include the lazily allocated bit if transient is requested.
 	VkMemoryPropertyFlags optimal =
 		VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |
-		(usage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) ?
-			VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT : 0;
+		((usage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) ?
+			VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT : 0);
 
 	if (!_gfx_allocd(&renderer->allocator, &backing->alloc,
 		VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, optimal,


### PR DESCRIPTION
I don't know what this actually affects but it looked potentially bad. The `|` operator has a higher precedence than the ternary operator, so the expression was parsed as `(DEVICE_LOCAL_BIT | (usage & TRANSIENT_ATTACHMENT_BIT)) ? LAZILY_ALLOCATED_BIT : 0`, which always picks the true branch (which is why I noticed; clang has a tautological comparison warning).