### PR TITLE
Improve ergonomics for bit fields in C++

### DIFF
--- a/include/groufix/core/deps.h
+++ b/include/groufix/core/deps.h
@@ -48,6 +48,8 @@ typedef enum GFXAccessMask
 
 } GFXAccessMask;
 
+GFX_BIT_FIELD(GFXAccessMask)
+
 
 /**
  * Dependency object definition.

--- a/include/groufix/core/formats.h
+++ b/include/groufix/core/formats.h
@@ -32,6 +32,8 @@ typedef enum GFXFormatType
 
 } GFXFormatType;
 
+GFX_BIT_FIELD(GFXFormatType)
+
 
 /**
  * Format component order (defines `comps` in GFXFormat).
@@ -62,6 +64,8 @@ typedef enum GFXOrder
 	// TODO: Add YUV/YCbCr support?
 
 } GFXOrder;
+
+GFX_BIT_FIELD(GFXOrder)
 
 
 /**
@@ -101,6 +105,8 @@ typedef enum GFXFormatFeatures
 
 } GFXFormatFeatures;
 
+GFX_BIT_FIELD(GFXFormatFeatures)
+
 
 /**
  * Fuzzy search flags.
@@ -112,6 +118,8 @@ typedef enum GFXFuzzyFlags
 	GFX_FUZZY_STRICT_DEPTH = 0x0003 // Both MIN_DEPTH and MAX_DEPTH.
 
 } GFXFuzzyFlags;
+
+GFX_BIT_FIELD(GFXFuzzyFlags)
 
 
 /**

--- a/include/groufix/core/heap.h
+++ b/include/groufix/core/heap.h
@@ -56,6 +56,7 @@ typedef enum GFXTopology
  */
 typedef enum GFXMemoryFlags
 {
+	GFX_MEMORY_NONE         = 0x0000,
 	GFX_MEMORY_HOST_VISIBLE = 0x0001, // i.e. mappable.
 	GFX_MEMORY_DEVICE_LOCAL = 0x0002, // Implied if GFX_MEMORY_HOST_VISIBLE is _not_ set.
 	GFX_MEMORY_READ         = 0x0004,
@@ -67,12 +68,15 @@ typedef enum GFXMemoryFlags
 
 } GFXMemoryFlags;
 
+GFX_BIT_FIELD(GFXMemoryFlags)
+
 
 /**
  * Buffer usage flags.
  */
 typedef enum GFXBufferUsage
 {
+	GFX_BUFFER_NONE          = 0x0000,
 	GFX_BUFFER_VERTEX        = 0x0001,
 	GFX_BUFFER_INDEX         = 0x0002,
 	GFX_BUFFER_UNIFORM       = 0x0004,
@@ -83,12 +87,15 @@ typedef enum GFXBufferUsage
 
 } GFXBufferUsage;
 
+GFX_BIT_FIELD(GFXBufferUsage)
+
 
 /**
  * Image usage flags.
  */
 typedef enum GFXImageUsage
 {
+	GFX_IMAGE_NONE           = 0x0000,
 	GFX_IMAGE_SAMPLED        = 0x0001,
 	GFX_IMAGE_SAMPLED_LINEAR = 0x0002,
 	GFX_IMAGE_SAMPLED_MINMAX = 0x0004,
@@ -100,6 +107,8 @@ typedef enum GFXImageUsage
 	GFX_IMAGE_TRANSIENT = 0x0040 // May NOT combine with non-attachment usages.
 
 } GFXImageUsage;
+
+GFX_BIT_FIELD(GFXImageUsage)
 
 
 /**
@@ -411,10 +420,13 @@ typedef enum GFXTransferFlags
 {
 	// TODO: Introduce GFX_TRANSFER_POOL, for pooling into 1 command buffer.
 	// TODO: We could reverse meaning and call it GFX_TRANSFER_FLUSH instead c:
+	GFX_TRANSFER_NONE  = 0x0000,
 	GFX_TRANSFER_ASYNC = 0x0001,
 	GFX_TRANSFER_BLOCK = 0x0002
 
 } GFXTransferFlags;
+
+GFX_BIT_FIELD(GFXTransferFlags)
 
 
 /**

--- a/include/groufix/core/keys.h
+++ b/include/groufix/core/keys.h
@@ -10,6 +10,8 @@
 #ifndef GFX_CORE_KEYS_H
 #define GFX_CORE_KEYS_H
 
+#include "groufix/def.h"
+
 
 /**
  * Keyboard modifiers (identical to GLFW modifiers).
@@ -17,6 +19,7 @@
  */
 typedef enum GFXModifier
 {
+	GFX_MOD_NONE      = 0x0000,
 	GFX_MOD_SHIFT     = 0x0001,
 	GFX_MOD_CONTROL   = 0x0002,
 	GFX_MOD_ALT       = 0x0004,
@@ -25,6 +28,8 @@ typedef enum GFXModifier
 	GFX_MOD_NUM_LOCK  = 0x0020
 
 } GFXModifier;
+
+GFX_BIT_FIELD(GFXModifier)
 
 
 /**

--- a/include/groufix/core/refs.h
+++ b/include/groufix/core/refs.h
@@ -28,6 +28,8 @@ typedef enum GFXImageAspect
 
 } GFXImageAspect;
 
+GFX_BIT_FIELD(GFXimageAspect)
+
 
 /**
  * Unified memory range (i.e. sub-resource).

--- a/include/groufix/core/renderer.h
+++ b/include/groufix/core/renderer.h
@@ -87,11 +87,14 @@ typedef enum GFXViewType
  */
 typedef enum GFXSamplerFlags
 {
+	GFX_SAMPLER_NONE         = 0x0000,
 	GFX_SAMPLER_ANISOTROPY   = 0x0001,
 	GFX_SAMPLER_COMPARE      = 0x0002,
 	GFX_SAMPLER_UNNORMALIZED = 0x0004
 
 } GFXSamplerFlags;
+
+GFX_BIT_FIELD(GFXSamplerFlags)
 
 
 /**
@@ -99,10 +102,13 @@ typedef enum GFXSamplerFlags
  */
 typedef enum GFXDepthFlags
 {
+	GFX_DEPTH_NONE    = 0x0000,
 	GFX_DEPTH_WRITE   = 0x0001,
 	GFX_DEPTH_BOUNDED = 0x0002
 
 } GFXDepthFlags;
+
+GFX_BIT_FIELD(GFXDepthFlags)
 
 
 /**
@@ -855,11 +861,14 @@ GFX_API bool gfx_set_samplers(GFXSet* set,
  */
 typedef enum GFXComputeFlags
 {
+	GFX_COMPUTE_NONE   = 0x0000,
 	GFX_COMPUTE_ASYNC  = 0x0001,
 	GFX_COMPUTE_BEFORE = 0x0002,
 	GFX_COMPUTE_AFTER  = 0x0004 // Overrules GFX_COMPUTE_BEFORE.
 
 } GFXComputeFlags;
+
+GFX_BIT_FIELD(GFXComputeFlags)
 
 
 /**

--- a/include/groufix/core/shader.h
+++ b/include/groufix/core/shader.h
@@ -31,6 +31,7 @@ typedef enum GFXShaderLanguage
  */
 typedef enum GFXShaderStage
 {
+	GFX_STAGE_ANY             = 0x0000,
 	GFX_STAGE_VERTEX          = 0x0001,
 	GFX_STAGE_TESS_CONTROL    = 0x0002,
 	GFX_STAGE_TESS_EVALUATION = 0x0004,
@@ -39,6 +40,8 @@ typedef enum GFXShaderStage
 	GFX_STAGE_COMPUTE         = 0x0020
 
 } GFXShaderStage;
+
+GFX_BIT_FIELD(GFXShaderStage)
 
 
 /**

--- a/include/groufix/core/window.h
+++ b/include/groufix/core/window.h
@@ -20,6 +20,7 @@
  */
 typedef enum GFXWindowFlags
 {
+	GFX_WINDOW_NONE          = 0x0000,
 	GFX_WINDOW_HIDDEN        = 0x0001, // Overrules all.
 	GFX_WINDOW_BORDERLESS    = 0x0002,
 	GFX_WINDOW_FOCUS         = 0x0004, // One-time action.
@@ -31,6 +32,8 @@ typedef enum GFXWindowFlags
 	GFX_WINDOW_TRIPLE_BUFFER = 0x0100  // Overrules GFX_WINDOW_DOUBLE_BUFFER.
 
 } GFXWindowFlags;
+
+GFX_BIT_FIELD(GFXWindowFlags)
 
 
 /**

--- a/include/groufix/def.h
+++ b/include/groufix/def.h
@@ -88,6 +88,16 @@
 
 
 /**
+ * Define an operator| for enum types in C++ mode.
+ */
+#if defined (__cplusplus)
+	#define GFX_BIT_FIELD(T) inline T operator|(T a, T b) { return (T)((int)a | (int)b); }
+#else
+	#define GFX_BIT_FIELD(T)
+#endif
+
+
+/**
  * groufix public atomic types.
  */
 #if defined (__cplusplus)


### PR DESCRIPTION
This PR does two things:
* It defines the `GFX_BIT_FIELD(T)` macro which defines a `T operator|(T a, T b)` function for C++. This lets C++ users avoid explicit casts when ORing together multiple flags.
* It adds `GFX_BUFFER_NONE`, `GFX_STAGE_NONE` and `GFX_MOD_NONE` as zero-values for their respective bit fields. C++ makes it awkward to use a zero flag values, since `0` is an integer literal which can't be implicitly converted to enum. There are probably more bit field enums which could use a `_NONE` option. Maybe we want it for every bit field?