### PR TITLE
Fix compilation on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,16 @@ else
 endif
 
 
+# Linker flags to start/end whole-archive sections
+ifeq ($(MACOS),ON)
+ WHOLE_ARCHIVE_BEGIN = -Wl,-all_load
+ WHOLE_ARCHIVE_END   =
+else
+ WHOLE_ARCHIVE_BEGIN = -Wl,--push-state,--whole-archive
+ WHOLE_ARCHIVE_END   = -Wl,--pop-state
+endif
+
+
 # Flags for all binaries
 ifeq ($(DEBUG),ON)
  DFLAGS = -g -Og
@@ -152,16 +162,6 @@ ifeq ($(MACOS),ON)
   -framework QuartzCore
 endif
 
-
-# Linker flags to start/end whole-archive sections
-ifeq ($(MACOS),ON)
- WHOLE_ARCHIVE_BEGIN = -Wl,-all_load
- WHOLE_ARCHIVE_END   =
-else
- WHOLE_ARCHIVE_BEGIN = -Wl,--push-state,--whole-archive
- WHOLE_ARCHIVE_END   = -Wl,--pop-state
-endif
-
 ifneq ($(CC_PREFIX),None) # Cross-compile
  LIB_LDFLAGS = $(LIB_LDFLAGS_WIN)
 else ifeq ($(OS),Windows_NT)
@@ -178,14 +178,16 @@ GLFW_FLAGS_ALL = \
  -DGLFW_BUILD_TESTS=OFF \
  -DGLFW_BUILD_DOCS=OFF
 
+GLFW_FLAGS_WIN = $(GLFW_FLAGS_ALL) -DGLFW_BUILD_WIN32=ON
+
 ifeq ($(MACOS),ON)
  GLFW_FLAGS_UNIX = $(GLFW_FLAGS_ALL) -DGLFW_BUILD_COCOA=ON
 else
-ifeq ($(USE_WAYLAND),ON)
- GLFW_FLAGS_UNIX = $(GLFW_FLAGS_ALL) -DGLFW_BUILD_X11=OFF -DGLFW_BUILD_WAYLAND=ON
-else
- GLFW_FLAGS_UNIX = $(GLFW_FLAGS_ALL) -DGLFW_BUILD_X11=ON -DGLFW_BUILD_WAYLAND=OFF
-endif
+ ifeq ($(USE_WAYLAND),ON)
+  GLFW_FLAGS_UNIX = $(GLFW_FLAGS_ALL) -DGLFW_BUILD_X11=OFF -DGLFW_BUILD_WAYLAND=ON
+ else
+  GLFW_FLAGS_UNIX = $(GLFW_FLAGS_ALL) -DGLFW_BUILD_X11=ON -DGLFW_BUILD_WAYLAND=OFF
+ endif
 endif
 
 SHADERC_FLAGS_ALL = \
@@ -235,12 +237,12 @@ SHADERC_MINGW_TOOLCHAIN = \
  -Dgtest_disable_pthreads=ON
 
 ifneq ($(CC_PREFIX),None) # Cross-compile
- GLFW_FLAGS        = $(GLFW_FLAGS_ALL) $(GLFW_MINGW_TOOLCHAIN)
+ GLFW_FLAGS        = $(GLFW_FLAGS_WIN) $(GLFW_MINGW_TOOLCHAIN)
  SHADERC_FLAGS     = $(SHADERC_FLAGS_ALL) $(SHADERC_MINGW_TOOLCHAIN) -G "Unix Makefiles"
  SPIRV_CROSS_FLAGS = $(SPIRV_CROSS_FLAGS_ALL) $(CMAKE_MINGW_TOOLCHAIN)
  CIMGUI_FLAGS      = $(CIMGUI_FLAGS_ALL) $(CMAKE_MINGW_TOOLCHAIN)
 else ifeq ($(OS),Windows_NT)
- GLFW_FLAGS        = $(GLFW_FLAGS_ALL) $(CMAKE_TOOLCHAIN) -G "MinGW Makefiles"
+ GLFW_FLAGS        = $(GLFW_FLAGS_WIN) $(CMAKE_TOOLCHAIN) -G "MinGW Makefiles"
  SHADERC_FLAGS     = $(SHADERC_FLAGS_ALL) $(CMAKE_TOOLCHAIN) -G "MinGW Makefiles"
  SPIRV_CROSS_FLAGS = $(SPIRV_CROSS_FLAGS_ALL) $(CMAKE_TOOLCHAIN) -G "MinGW Makefiles"
  CIMGUI_FLAGS      = $(CIMGUI_FLAGS_ALL) $(CMAKE_TOOLCHAIN) -G "MinGW Makefiles"

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,18 @@ ifeq ($(MACOS),ON)
   -framework CoreFoundation \
   -framework CoreGraphics \
   -framework Cocoa \
-  -framework IOKit
+  -framework IOKit \
+  -framework QuartzCore
+endif
+
+
+# Linker flags to start/end whole-archive sections
+ifeq ($(MACOS),ON)
+ WHOLE_ARCHIVE_BEGIN = -Wl,-all_load
+ WHOLE_ARCHIVE_END   =
+else
+ WHOLE_ARCHIVE_BEGIN = -Wl,--push-state,--whole-archive
+ WHOLE_ARCHIVE_END   = -Wl,--pop-state
 endif
 
 ifneq ($(CC_PREFIX),None) # Cross-compile
@@ -167,10 +178,14 @@ GLFW_FLAGS_ALL = \
  -DGLFW_BUILD_TESTS=OFF \
  -DGLFW_BUILD_DOCS=OFF
 
+ifeq ($(MACOS),ON)
+ GLFW_FLAGS_UNIX = $(GLFW_FLAGS_ALL) -DGLFW_BUILD_COCOA=ON
+else
 ifeq ($(USE_WAYLAND),ON)
  GLFW_FLAGS_UNIX = $(GLFW_FLAGS_ALL) -DGLFW_BUILD_X11=OFF -DGLFW_BUILD_WAYLAND=ON
 else
  GLFW_FLAGS_UNIX = $(GLFW_FLAGS_ALL) -DGLFW_BUILD_X11=ON -DGLFW_BUILD_WAYLAND=OFF
+endif
 endif
 
 SHADERC_FLAGS_ALL = \
@@ -362,7 +377,7 @@ $(TEMP)$(SUB)/viz/%.o: viz/%.c
 # Library file
 $(BIN)$(SUB)/libgroufix$(LIBEXT): $(DEPS) $(DEPS_EXPORT) $(LIB_OBJS)
 	@$(MAKE) $(MFLAGS_ALL) MAKEDIR=$(@D) .makedir
-	$(CXX) $(LIB_OBJS) -o $@ $(DEPS) -Wl,--push-state,--whole-archive $(DEPS_EXPORT) -Wl,--pop-state $(LIB_LDFLAGS)
+	$(CXX) $(LIB_OBJS) -o $@ $(DEPS) $(WHOLE_ARCHIVE_BEGIN) $(DEPS_EXPORT) $(WHOLE_ARCHIVE_END) $(LIB_LDFLAGS)
 
 # Program files
 $(BIN)$(SUB)/grouviz$(BINEXT): $(VIZ_OBJS) $(BIN)$(SUB)/libgroufix$(LIBEXT)


### PR DESCRIPTION
macOS's linker has neither `--push-state`, `--pop-state` or `--whole-archive`, it just has `-all_load`.

Also, since last time I messed with Groufix, it apparently needs the QuartzCore framework now.

I also removed GLFW_BUILD_X11 and GLFW_BUILD_WAYLAND from build options when compiling for macOS, since it doesn't really make sense there.